### PR TITLE
Replica set support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,4 @@ jobs:
           key: v2-dependencies-{{ checksum "package.json" }}
 
       - run: yarn test
+      - run: yarn test:replicaSet

--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -12,7 +12,14 @@ const options = {
 
 if (process.env.TEST_REPLICASET) {
   options.mongodbMemoryServerOptions = {
-    replSet: {storageEngine: 'wiredTiger'},
+    replSet: {
+      dbName: 'jest',
+      storageEngine: 'wiredTiger'
+    },
+    binary: {
+      version: '4.0.3',
+      skipMD5: true
+    },
     autoStart: false
   };
 }

--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -13,8 +13,7 @@ const options = {
 if (process.env.TEST_REPLICASET) {
   options.mongodbMemoryServerOptions = {
     replSet: {
-      dbName: 'jest',
-      storageEngine: 'wiredTiger'
+      dbName: 'jest'
     },
     binary: {
       version: '4.0.3',

--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+const options = {
   mongodbMemoryServerOptions: {
     instance: {
       dbName: 'jest'
@@ -9,3 +9,12 @@ module.exports = {
     autoStart: false
   }
 };
+
+if (process.env.TEST_REPLICASET) {
+  options.mongodbMemoryServerOptions = {
+    replSet: {storageEngine: 'wiredTiger'},
+    autoStart: false
+  };
+}
+
+module.exports = options;

--- a/mongo-is-replica.test.js
+++ b/mongo-is-replica.test.js
@@ -27,5 +27,5 @@ describe('insert', () => {
 
       expect(result.members[0].stateStr).toBe('PRIMARY');
     } else await expect(test_cmd).rejects.toThrow('not running with --replSet');
-  }, 30000);
+  });
 });

--- a/mongo-is-replica.test.js
+++ b/mongo-is-replica.test.js
@@ -1,0 +1,31 @@
+const {MongoClient} = require('mongodb');
+
+describe('insert', () => {
+  let connection;
+  let db;
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(process.env.MONGO_URL, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true
+    });
+    db = await connection.db();
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  // Differs depending on which suite type of connection is used
+  // eslint-disable-next-line jest/no-if
+  it(`should ${process.env.TEST_REPLICASET ? 'not' : ''} connect to a replica set`, async () => {
+    const test_cmd = db.admin().command({replSetGetStatus: 1});
+
+    // eslint-disable-next-line jest/no-if
+    if (process.env.TEST_REPLICASET) {
+      const result = await test_cmd;
+
+      expect(result.members[0].stateStr).toBe('PRIMARY');
+    } else await expect(test_cmd).rejects.toThrow('not running with --replSet');
+  }, 30000);
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "lint": "eslint . --fix --ext .js,.json,.ts --quiet",
     "test": "jest",
-    "test:replicaSet": "export TEST_REPLICASET=true && jest"
+    "test:replicaSet": "cross-env TEST_REPLICASET=true && jest",
+    "test:all": "npm test && npm run test:replicaSet"
   },
   "husky": {
     "hooks": {
@@ -49,6 +50,7 @@
   "devDependencies": {
     "@shelf/eslint-config": "0.16.0",
     "@shelf/prettier-config": "0.0.7",
+    "cross-env": "^7.0.2",
     "eslint": "7.1.0",
     "husky": "4.2.5",
     "jest": "26.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "lint": "eslint . --fix --ext .js,.json,.ts --quiet",
-    "test": "jest"
+    "test": "jest",
+    "test:replicaSet": "export TEST_REPLICASET=true && jest"
   },
   "husky": {
     "hooks": {

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ If you have a custom `jest.config.js` make sure you remove `testEnvironment` pro
 
 - Standard
 
-  See [mongodb-memory-server: MongoMemoryServer](https://github.com/nodkz/ mongodb-memory-server#available-options-for-mongomemoryserver)
+  See [mongodb-memory-server: MongoMemoryServer](https://github.com/nodkz/mongodb-memory-server#available-options-for-mongomemoryserver)
 
   ```js
   module.exports = {
@@ -45,7 +45,7 @@ If you have a custom `jest.config.js` make sure you remove `testEnvironment` pro
 
 - Replica Set
 
-  See [mongodb-memory-server: MongoMemoryReplSet](https://github.com/nodkz/ mongodb-memory-server#available-options-for-mongomemoryreplset)
+  See [mongodb-memory-server: MongoMemoryReplSet](https://github.com/nodkz/mongodb-memory-server#available-options-for-mongomemoryreplset)
 
   ```js
   module.exports = {

--- a/readme.md
+++ b/readme.md
@@ -51,8 +51,7 @@ If you have a custom `jest.config.js` make sure you remove `testEnvironment` pro
   module.exports = {
     mongodbMemoryServerOptions: {
       replSet: {
-        dbName: 'jest',
-        storageEngine: 'wiredTiger'
+        dbName: 'jest'
       },
       binary: {
         version: '4.0.3',

--- a/readme.md
+++ b/readme.md
@@ -24,22 +24,44 @@ If you have a custom `jest.config.js` make sure you remove `testEnvironment` pro
 
 ### 2. Create `jest-mongodb-config.js`
 
-See [mongodb-memory-server](https://github.com/nodkz/mongodb-memory-server#available-options)
+- Standard
 
-```js
-module.exports = {
-  mongodbMemoryServerOptions: {
-    instance: {
-      dbName: 'jest'
-    },
-    binary: {
-      version: '4.0.3',
-      skipMD5: true
-    },
-    autoStart: false
-  }
-};
-```
+  See [mongodb-memory-server: MongoMemoryServer](https://github.com/nodkz/ mongodb-memory-server#available-options-for-mongomemoryserver)
+
+  ```js
+  module.exports = {
+    mongodbMemoryServerOptions: {
+      instance: {
+        dbName: 'jest'
+      },
+      binary: {
+        version: '4.0.3',
+        skipMD5: true
+      },
+      autoStart: false
+    }
+  };
+  ```
+
+- Replica Set
+
+  See [mongodb-memory-server: MongoMemoryReplSet](https://github.com/nodkz/ mongodb-memory-server#available-options-for-mongomemoryreplset)
+
+  ```js
+  module.exports = {
+    mongodbMemoryServerOptions: {
+      replSet: {
+        dbName: 'jest',
+        storageEngine: 'wiredTiger'
+      },
+      binary: {
+        version: '4.0.3',
+        skipMD5: true
+      },
+      autoStart: false
+    }
+  };
+  ```
 
 ### 3. Configure MongoDB client
 


### PR DESCRIPTION
Attempts to close  #152  with replica set support.

Currently adds 1 test file that checks for a primary member when run in replicaSet mode.

This test file _does_ rely on some if statements to tell the difference between the running instances of mongo. 
I am open to suggestions on a better method if one exists.

