### PR TITLE
feat(paralell): enable parallel tests generating an unique database name per test file, fix #206

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -20,7 +20,7 @@ module.exports = class MongoEnvironment extends NodeEnvironment {
     const globalConfig = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
 
     this.global.__MONGO_URI__ = globalConfig.mongoUri;
-    this.global.__MONGO_DB_NAME__ = uuid.v4();
+    this.global.__MONGO_DB_NAME__ = globalConfig.mongoDBName || uuid.v4();
 
     await super.setup();
   }

--- a/environment.js
+++ b/environment.js
@@ -1,9 +1,13 @@
 const NodeEnvironment = require('jest-environment-node');
 const path = require('path');
 const fs = require('fs');
-const globalConfigPath = path.join(__dirname, 'globalConfig.json');
+const uuid = require('uuid');
 
 const debug = require('debug')('jest-mongodb:environment');
+
+const cwd = process.cwd();
+
+const globalConfigPath = path.join(cwd, 'globalConfig.json');
 
 module.exports = class MongoEnvironment extends NodeEnvironment {
   constructor(config) {
@@ -16,7 +20,7 @@ module.exports = class MongoEnvironment extends NodeEnvironment {
     const globalConfig = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
 
     this.global.__MONGO_URI__ = globalConfig.mongoUri;
-    this.global.__MONGO_DB_NAME__ = globalConfig.mongoDBName;
+    this.global.__MONGO_DB_NAME__ = uuid.v4();
 
     await super.setup();
   }

--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -1,8 +1,5 @@
 module.exports = {
   mongodbMemoryServerOptions: {
-    instance: {
-      dbName: 'jest'
-    },
     binary: {
       skipMD5: true
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "cwd": "0.10.0",
     "debug": "4.1.1",
-    "mongodb-memory-server": "6.6.1"
+    "mongodb-memory-server": "6.6.1",
+    "uuid": "8.1.0"
   },
   "devDependencies": {
     "@shelf/eslint-config": "0.16.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
     "preset": "./jest-preset.js"
   },
   "dependencies": {
-    "cwd": "0.10.0",
     "debug": "4.1.1",
-    "mongodb-memory-server": "6.6.1",
     "uuid": "8.1.0"
   },
   "devDependencies": {
@@ -57,7 +55,8 @@
     "prettier": "2.0.5"
   },
   "peerDependencies": {
-    "mongodb": "3.x.x"
+    "mongodb": "3.x.x",
+    "mongodb-memory-server": "*"
   },
   "engines": {
     "node": ">=8"

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,20 @@ See [mongodb-memory-server](https://github.com/nodkz/mongodb-memory-server#avail
 ```js
 module.exports = {
   mongodbMemoryServerOptions: {
+    binary: {
+      version: '4.0.3',
+      skipMD5: true
+    },
+    autoStart: false
+  }
+};
+```
+
+To use the same database for all tests pass the config like this:
+
+```js
+module.exports = {
+  mongodbMemoryServerOptions: {
     instance: {
       dbName: 'jest'
     },

--- a/setup.js
+++ b/setup.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
 const {resolve, join} = require('path');
-const cwd = require('cwd');
 const MongodbMemoryServer = require('mongodb-memory-server');
-const globalConfigPath = join(__dirname, 'globalConfig.json');
 
 const debug = require('debug')('jest-mongodb:setup');
 const mongod = new MongodbMemoryServer.default(getMongodbMemoryOptions());
+
+const cwd = process.cwd();
+const globalConfigPath = join(cwd, 'globalConfig.json');
 
 module.exports = async () => {
   if (!mongod.isRunning) {
@@ -13,7 +14,6 @@ module.exports = async () => {
   }
 
   const mongoConfig = {
-    mongoDBName: getMongodbMemoryOptions().instance.dbName,
     mongoUri: await mongod.getConnectionString()
   };
 
@@ -28,7 +28,7 @@ module.exports = async () => {
 
 function getMongodbMemoryOptions() {
   try {
-    const {mongodbMemoryServerOptions} = require(resolve(cwd(), 'jest-mongodb-config.js'));
+    const {mongodbMemoryServerOptions} = require(resolve(cwd, 'jest-mongodb-config.js'));
 
     return mongodbMemoryServerOptions;
   } catch (e) {

--- a/setup.js
+++ b/setup.js
@@ -13,8 +13,11 @@ module.exports = async () => {
     await mongod.start();
   }
 
+  const options = getMongodbMemoryOptions();
+
   const mongoConfig = {
-    mongoUri: await mongod.getConnectionString()
+    mongoUri: await mongod.getConnectionString(),
+    mongoDBName: options.instance.dbName
   };
 
   // Write global config to disk because all tests run in different contexts.
@@ -33,9 +36,6 @@ function getMongodbMemoryOptions() {
     return mongodbMemoryServerOptions;
   } catch (e) {
     return {
-      instance: {
-        dbName: 'jest'
-      },
       binary: {
         skipMD5: true
       },


### PR DESCRIPTION
`path.join(cwd)` is more stable then `__dirname` when running inside a monorepo