### PR TITLE
Do not request mongodb-memory-server as peer dependency if it is already a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "prettier": "2.0.5"
   },
   "peerDependencies": {
-    "mongodb": "3.x.x",
-    "mongodb-memory-server": "*"
+    "mongodb": "3.x.x"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
I do not think it makes sense to have it in both categories as it is installed anyway.