### PR TITLE
Fix deprecation warning by using mongod.getUri()

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -16,7 +16,7 @@ module.exports = async () => {
   const options = getMongodbMemoryOptions();
 
   const mongoConfig = {
-    mongoUri: await mongod.getConnectionString(),
+    mongoUri: await mongod.getUri(),
     mongoDBName: options.instance.dbName
   };
 


### PR DESCRIPTION
Replace the deprecated call of `mongod.getConnectionString()` by `mongod.getUri()` as suggested by the [deprecation message](https://github.com/nodkz/mongodb-memory-server/blob/30ba1a000b52dcbfa2a7093b8f92cdde23ed5e51/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts#L256-L267).

Fix #262