### PR TITLE
Separate DB per Jest Worker (Fixes #272)

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -2,12 +2,16 @@ const NodeEnvironment = require('jest-environment-node');
 const path = require('path');
 const fs = require('fs');
 const uuid = require('uuid');
+const {MongoMemoryServer} = require('mongodb-memory-server');
+const {getMongodbMemoryOptions} = require('./helpers');
 
 const debug = require('debug')('jest-mongodb:environment');
 
 const cwd = process.cwd();
 
 const globalConfigPath = path.join(cwd, 'globalConfig.json');
+
+let mongo = new MongoMemoryServer(getMongodbMemoryOptions());
 
 module.exports = class MongoEnvironment extends NodeEnvironment {
   constructor(config) {
@@ -19,7 +23,14 @@ module.exports = class MongoEnvironment extends NodeEnvironment {
 
     const globalConfig = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
 
-    this.global.__MONGO_URI__ = globalConfig.mongoUri;
+    if (globalConfig.mongoUri) {
+      this.global.__MONGO_URI__ = globalConfig.mongoUri;
+    } else {
+      await mongo.start();
+
+      this.global.__MONGO_URI__ = mongo.getUri();
+    }
+
     this.global.__MONGO_DB_NAME__ = globalConfig.mongoDBName || uuid.v4();
 
     await super.setup();
@@ -27,6 +38,8 @@ module.exports = class MongoEnvironment extends NodeEnvironment {
 
   async teardown() {
     debug('Teardown MongoDB Test Environment');
+
+    await mongo.stop();
 
     await super.teardown();
   }

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,39 @@
+const {resolve} = require('path');
+
+const cwd = process.cwd();
+
+module.exports.getMongodbMemoryOptions = function () {
+  try {
+    const {mongodbMemoryServerOptions} = require(resolve(cwd, 'jest-mongodb-config.js'));
+
+    return mongodbMemoryServerOptions;
+  } catch (e) {
+    return {
+      binary: {
+        skipMD5: true,
+      },
+      autoStart: false,
+      instance: {},
+    };
+  }
+};
+
+module.exports.getMongoURLEnvName = function () {
+  try {
+    const {mongoURLEnvName} = require(resolve(cwd, 'jest-mongodb-config.js'));
+
+    return mongoURLEnvName || 'MONGO_URL';
+  } catch (e) {
+    return 'MONGO_URL';
+  }
+};
+
+module.exports.getSeparateMongoInstancesFlag = function () {
+  try {
+    const {separateMongoInstances} = require(resolve(cwd, 'jest-mongodb-config.js'));
+
+    return separateMongoInstances;
+  } catch (e) {
+    return false;
+  }
+};

--- a/mongo-aggregate.test.js
+++ b/mongo-aggregate.test.js
@@ -5,7 +5,6 @@ describe('insert', () => {
   let connection;
   let db;
 
-  console.log(uri);
 
   beforeAll(async () => {
     connection = await MongoClient.connect(uri, {

--- a/mongo-aggregate.test.js
+++ b/mongo-aggregate.test.js
@@ -1,10 +1,11 @@
 const {MongoClient} = require('mongodb');
-const {mongoURLEnvName} = require('./jest-mongodb-config');
 
 describe('insert', () => {
-  const uri = mongoURLEnvName ? process.env[mongoURLEnvName] : process.env.MONGO_URL;
+  const uri = global.__MONGO_URI__;
   let connection;
   let db;
+
+  console.log(uri);
 
   beforeAll(async () => {
     connection = await MongoClient.connect(uri, {

--- a/mongo-insert.test.js
+++ b/mongo-insert.test.js
@@ -5,7 +5,6 @@ describe('insert', () => {
   let connection;
   let db;
 
-  console.log(uri);
 
   beforeAll(async () => {
     connection = await MongoClient.connect(uri, {

--- a/mongo-insert.test.js
+++ b/mongo-insert.test.js
@@ -1,10 +1,11 @@
 const {MongoClient} = require('mongodb');
-const {mongoURLEnvName} = require('./jest-mongodb-config');
 
 describe('insert', () => {
-  const uri = mongoURLEnvName ? process.env[mongoURLEnvName] : process.env.MONGO_URL;
+  const uri = global.__MONGO_URI__;
   let connection;
   let db;
+
+  console.log(uri);
 
   beforeAll(async () => {
     connection = await MongoClient.connect(uri, {

--- a/mongo-parallelism.test.js
+++ b/mongo-parallelism.test.js
@@ -1,0 +1,31 @@
+const {MongoClient} = require('mongodb');
+const {getSeparateMongoInstancesFlag} = require('./helpers');
+
+describe('parallelism: first worker', () => {
+  const uri = global.__MONGO_URI__;
+  let connection;
+  let db;
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(uri, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    db = await connection.db();
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  it('should have separate database', async () => {
+    const collection = db.collection('parallelism-test');
+
+    await collection.insertOne({a: 1});
+    const count = await collection.count({});
+
+    if (getSeparateMongoInstancesFlag()) {
+      expect(count).toBe(1);
+    }
+  });
+});

--- a/mongo-parallelism2.test.js
+++ b/mongo-parallelism2.test.js
@@ -1,0 +1,31 @@
+const {MongoClient} = require('mongodb');
+const {getSeparateMongoInstancesFlag} = require('./helpers');
+
+describe('parallelism: second worker', () => {
+  const uri = global.__MONGO_URI__;
+  let connection;
+  let db;
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(uri, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    db = await connection.db();
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  it('should have separate database', async () => {
+    const collection = db.collection('parallelism-test');
+
+    await collection.insertMany([{a: 1}, {b: 2}]);
+    const count = await collection.count({});
+
+    if (getSeparateMongoInstancesFlag()) {
+      expect(count).toBe(2);
+    }
+  });
+});

--- a/mongo-parallelism3.test.js
+++ b/mongo-parallelism3.test.js
@@ -1,0 +1,31 @@
+const {MongoClient} = require('mongodb');
+const {getSeparateMongoInstancesFlag} = require('./helpers');
+
+describe('parallelism: third worker', () => {
+  const uri = global.__MONGO_URI__;
+  let connection;
+  let db;
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(uri, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    db = await connection.db();
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  it('should have separate database', async () => {
+    const collection = db.collection('parallelism-test');
+
+    await collection.insertMany([{a: 1}, {b: 2}, {c: 3}]);
+    const count = await collection.count({});
+
+    if (getSeparateMongoInstancesFlag()) {
+      expect(count).toBe(3);
+    }
+  });
+});

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Make sure `mongodb` is installed in the project as well, as it's required as a p
 
 ```js
 module.exports = {
-  preset: '@shelf/jest-mongodb'
+  preset: '@shelf/jest-mongodb',
 };
 ```
 
@@ -31,11 +31,11 @@ module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
       version: '4.0.3',
-      skipMD5: true
+      skipMD5: true,
     },
     autoStart: false,
-    instance: {}
-  }
+    instance: {},
+  },
 };
 ```
 
@@ -46,13 +46,29 @@ module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
       version: '4.0.3',
-      skipMD5: true
+      skipMD5: true,
     },
     instance: {
-      dbName: 'jest'
+      dbName: 'jest',
     },
-    autoStart: false
-  }
+    autoStart: false,
+  },
+};
+```
+
+To use separate database for each jest worker pass the `separateMongoInstances: true` :
+
+```js
+module.exports = {
+  mongodbMemoryServerOptions: {
+    binary: {
+      skipMD5: true,
+    },
+    autoStart: false,
+    instance: {},
+  },
+
+  separateMongoInstances: true,
 };
 ```
 
@@ -63,11 +79,11 @@ module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
       version: '4.0.3',
-      skipMD5: true
+      skipMD5: true,
     },
     instance: {},
-    autoStart: false
-  }
+    autoStart: false,
+  },
 };
 ```
 
@@ -78,18 +94,18 @@ module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
       version: '4.0.3',
-      skipMD5: true
+      skipMD5: true,
     },
     instance: {},
-    autoStart: false
+    autoStart: false,
   },
-  mongoURLEnvName: 'MONGODB_URI'
+  mongoURLEnvName: 'MONGODB_URI',
 };
 ```
 
 ### 3. Configure MongoDB client
 
-Library sets the `process.env.MONGO_URL` for your convenience
+Library sets the `process.env.MONGO_URL` for your convenience, but using of `global.__MONGO_URI__` is preferable as it works with ` separateMongoInstances: true`
 
 ```js
 const {MongoClient} = require('mongodb');
@@ -99,9 +115,9 @@ describe('insert', () => {
   let db;
 
   beforeAll(async () => {
-    connection = await MongoClient.connect(process.env.MONGO_URL, {
+    connection = await MongoClient.connect(global.__MONGO_URI__, {
       useNewUrlParser: true,
-      useUnifiedTopology: true
+      useUnifiedTopology: true,
     });
     db = await connection.db();
   });
@@ -140,18 +156,17 @@ beforeEach(async () => {
 
 <sub>See [this issue](https://github.com/shelfio/jest-mongodb/issues/173) for discussion</sub>
 
-
 #### 6. Jest watch mode gotcha
 
-This package creates the file `globalConfig.json` in the project root, when using jest `--watch` flag, changes to `globalConfig.json` can cause an infinite loop 
+This package creates the file `globalConfig.json` in the project root, when using jest `--watch` flag, changes to `globalConfig.json` can cause an infinite loop
 
-In order to avoid this unwanted behaviour, add `globalConfig` to ignored files in watch mode in the Jest configuation 
+In order to avoid this unwanted behaviour, add `globalConfig` to ignored files in watch mode in the Jest configuation
 
 ```js
 // jest.config.js
 module.exports = {
   watchPathIgnorePatterns: ['globalConfig'],
-}
+};
 ```
 
 ## See Also

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ module.exports = {
 };
 ```
 
-To use separate database for each jest worker pass the `separateMongoInstances: true` :
+To use separate database for each jest worker pass the `separateMongoInstances: true` (doesn't create `process.env` variable when using this option):
 
 ```js
 module.exports = {

--- a/setup.js
+++ b/setup.js
@@ -1,6 +1,11 @@
 const fs = require('fs');
-const {resolve, join} = require('path');
+const {join} = require('path');
 const {MongoMemoryServer} = require('mongodb-memory-server');
+const {
+  getMongodbMemoryOptions,
+  getMongoURLEnvName,
+  getSeparateMongoInstancesFlag,
+} = require('./helpers');
 const cwd = process.cwd();
 
 const debug = require('debug')('jest-mongodb:setup');
@@ -9,49 +14,29 @@ const mongod = new MongoMemoryServer(getMongodbMemoryOptions());
 const globalConfigPath = join(cwd, 'globalConfig.json');
 
 module.exports = async () => {
-  if (!mongod.isRunning) {
-    await mongod.start();
+  const options = getMongodbMemoryOptions();
+
+  const mongoConfig = {};
+
+  //if we run one mongodb instance for all tests
+  if (!getSeparateMongoInstancesFlag()) {
+    if (!mongod.isRunning) {
+      await mongod.start();
+    }
+
+    const mongoURLEnvName = getMongoURLEnvName();
+
+    mongoConfig.mongoUri = await mongod.getUri();
+
+    process.env[mongoURLEnvName] = mongoConfig.mongoUri;
+
+    // Set reference to mongod in order to close the server during teardown.
+    global.__MONGOD__ = mongod;
   }
 
-  const options = getMongodbMemoryOptions();
-  const mongoURLEnvName = getMongoURLEnvName();
-
-  const mongoConfig = {
-    mongoUri: await mongod.getUri(),
-    mongoDBName: options.instance.dbName,
-  };
+  mongoConfig.mongoDBName = options.instance.dbName;
 
   // Write global config to disk because all tests run in different contexts.
   fs.writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
   debug('Config is written');
-
-  // Set reference to mongod in order to close the server during teardown.
-  global.__MONGOD__ = mongod;
-  process.env[mongoURLEnvName] = mongoConfig.mongoUri;
 };
-
-function getMongodbMemoryOptions() {
-  try {
-    const {mongodbMemoryServerOptions} = require(resolve(cwd, 'jest-mongodb-config.js'));
-
-    return mongodbMemoryServerOptions;
-  } catch (e) {
-    return {
-      binary: {
-        skipMD5: true,
-      },
-      autoStart: false,
-      instance: {},
-    };
-  }
-}
-
-function getMongoURLEnvName() {
-  try {
-    const {mongoURLEnvName} = require(resolve(cwd, 'jest-mongodb-config.js'));
-
-    return mongoURLEnvName || 'MONGO_URL';
-  } catch (e) {
-    return 'MONGO_URL';
-  }
-}

--- a/teardown.js
+++ b/teardown.js
@@ -2,5 +2,7 @@ const debug = require('debug')('jest-mongodb:teardown');
 
 module.exports = async function () {
   debug('Teardown mongod');
-  await global.__MONGOD__.stop();
+  if (global.__MONGOD__) {
+    await global.__MONGOD__.stop();
+  }
 };


### PR DESCRIPTION
Now if option ` separateMongoInstances: true` passed in `jest-mongodb-config.js`, jest-mongodb will start distinct mongodb instance for each jest worker. If this option passed, `process.env` variable for mongo uri will not be created, use `global.__MONGO_URI__` instead.

See https://github.com/shelfio/jest-mongodb/issues/272 