### PR TITLE
call environment super method with second arg

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -14,8 +14,8 @@ const globalConfigPath = path.join(cwd, 'globalConfig.json');
 let mongo = new MongoMemoryServer(getMongodbMemoryOptions());
 
 module.exports = class MongoEnvironment extends NodeEnvironment {
-  constructor(config) {
-    super(config);
+  constructor(config, context) {
+    super(config, context);
   }
 
   async setup() {


### PR DESCRIPTION
Jest environment classes are initialized with two args (config and context).

While this preset doesn't need the context, not calling `super` with it breaks attempts to wrap the environment with other customizations. I ran into this while trying to use Datadog's dd-trace package to instrument tests, because it expects to have access to the context arg when wrapping the environment class 

https://docs.datadoghq.com/continuous_integration/setup_tests/javascript/?tab=jest

https://github.com/DataDog/dd-trace-js/blob/master/packages/datadog-plugin-jest/src/jest-environment.js#L36