### PR TITLE
Add `MongoMemoryReplSet` support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,4 @@ jobs:
           key: v2-dependencies-{{ checksum "package.json" }}
 
       - run: yarn test
+      - run: yarn test:repl

--- a/environment.js
+++ b/environment.js
@@ -2,7 +2,7 @@ const NodeEnvironment = require('jest-environment-node');
 const path = require('path');
 const fs = require('fs');
 const uuid = require('uuid');
-const {MongoMemoryServer} = require('mongodb-memory-server');
+const {MongoMemoryServer, MongoMemoryReplSet} = require('mongodb-memory-server');
 const {getMongodbMemoryOptions} = require('./helpers');
 
 const debug = require('debug')('jest-mongodb:environment');
@@ -10,8 +10,12 @@ const debug = require('debug')('jest-mongodb:environment');
 const cwd = process.cwd();
 
 const globalConfigPath = path.join(cwd, 'globalConfig.json');
+const options = getMongodbMemoryOptions();
+const isReplSet = Boolean(options.replSet);
 
-let mongo = new MongoMemoryServer(getMongodbMemoryOptions());
+debug(`isReplSet`, isReplSet);
+
+let mongo = isReplSet ? new MongoMemoryReplSet(options) : new MongoMemoryServer(options);
 
 module.exports = class MongoEnvironment extends NodeEnvironment {
   constructor(config, context) {

--- a/helpers.js
+++ b/helpers.js
@@ -1,10 +1,11 @@
 const {resolve} = require('path');
 
 const cwd = process.cwd();
+const configFile = process.env.MONGO_MEMORY_SERVER_FILE || 'jest-mongodb-config.js';
 
 module.exports.getMongodbMemoryOptions = function () {
   try {
-    const {mongodbMemoryServerOptions} = require(resolve(cwd, 'jest-mongodb-config.js'));
+    const {mongodbMemoryServerOptions} = require(resolve(cwd, configFile));
 
     return mongodbMemoryServerOptions;
   } catch (e) {
@@ -20,7 +21,7 @@ module.exports.getMongodbMemoryOptions = function () {
 
 module.exports.getMongoURLEnvName = function () {
   try {
-    const {mongoURLEnvName} = require(resolve(cwd, 'jest-mongodb-config.js'));
+    const {mongoURLEnvName} = require(resolve(cwd, configFile));
 
     return mongoURLEnvName || 'MONGO_URL';
   } catch (e) {
@@ -30,7 +31,7 @@ module.exports.getMongoURLEnvName = function () {
 
 module.exports.shouldUseSharedDBForAllJestWorkers = function () {
   try {
-    const {useSharedDBForAllJestWorkers} = require(resolve(cwd, 'jest-mongodb-config.js'));
+    const {useSharedDBForAllJestWorkers} = require(resolve(cwd, configFile));
 
     if (typeof useSharedDBForAllJestWorkers === 'undefined') {
       return true;

--- a/jest-mongodb-config-repl.js
+++ b/jest-mongodb-config-repl.js
@@ -1,0 +1,14 @@
+module.exports = {
+  mongodbMemoryServerOptions: {
+    binary: {
+      skipMD5: true,
+    },
+    autoStart: false,
+    instance: {},
+    replSet: {
+      count: 4,
+      storageEngine: 'wiredTiger',
+    },
+  },
+  mongoURLEnvName: 'MONGO_URL',
+};

--- a/mongo-insert.test.js
+++ b/mongo-insert.test.js
@@ -5,7 +5,6 @@ describe('insert', () => {
   let connection;
   let db;
 
-
   beforeAll(async () => {
     connection = await MongoClient.connect(uri, {
       useNewUrlParser: true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "lint": "eslint . --fix --ext .js,.json,.ts --quiet",
-    "test": "jest"
+    "test": "jest",
+    "test:repl": "MONGO_MEMORY_SERVER_FILE=jest-mongodb-config-repl.js jest"
   },
   "husky": {
     "hooks": {

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,25 @@ module.exports = {
 };
 ```
 
+To use mongo as a replica set you must add the `replSet` config object and set
+`count` and `storageEngine` fields:
+
+```js
+module.exports = {
+  mongodbMemoryServerOptions: {
+    binary: {
+      skipMD5: true,
+    },
+    autoStart: false,
+    instance: {},
+    replSet: {
+      count: 3,
+      storageEngine: 'wiredTiger',
+    },
+  },
+};
+```
+
 ### 3. Configure MongoDB client
 
 Library sets the `process.env.MONGO_URL` for your convenience, but using of `global.__MONGO_URI__` is preferable as it works with ` useSharedDBForAllJestWorkers: false`


### PR DESCRIPTION
- Add replica set support. It just need to add the `replSet` field in `jest-mongodb-config.js` to start working as a replica set.
- Add test script with replica set enabled

Resolve #152 