### PR TITLE
feat: add support for Yarn PnP mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "prettier": "2.5.1"
   },
   "peerDependencies": {
-    "mongodb": "3.x.x || 4.x"
+    "mongodb": "3.x.x || 4.x",
+    "jest-environment-node": "27.x.x"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
`jest-environment-node` [is being required](https://github.com/shelfio/jest-mongodb/blob/d6bcc3c667ea03d80c66c6072c98dbd32ba5bd4f/environment.js#L1) though it was not being specified as a peer dependency.
This PR adds it as a peer dependency so that it'll play nice with Yarn's PnP mode
Feel free to suggest a more loose version requirement