### PR TITLE
Use default export of jest-environment if present

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -13,11 +13,13 @@ const globalConfigPath = path.join(cwd, 'globalConfig.json');
 const options = getMongodbMemoryOptions();
 const isReplSet = Boolean(options.replSet);
 
+const TestEnvironment = NodeEnvironment.default ? NodeEnvironment.default : NodeEnvironment;
+
 debug(`isReplSet`, isReplSet);
 
 let mongo = isReplSet ? new MongoMemoryReplSet(options) : new MongoMemoryServer(options);
 
-module.exports = class MongoEnvironment extends NodeEnvironment {
+module.exports = class MongoEnvironment extends TestEnvironment {
   constructor(config, context) {
     super(config, context);
   }


### PR DESCRIPTION
Jest v28 is going to start using ESM, and the latest release candidate
has started exporting modules with ESM syntax:

https://github.com/facebook/jest/pull/12340

This breaks jest-mongodb when importing jest-environment-node. In order
to properly import this module when running in jest v28 we need to look
for the default export.

If the default export is present, use that, otherwise use the test
environment as normal.