### PR TITLE
use rootDir instead of cwd for globalConfig location

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -11,9 +11,6 @@ const uuid = require('uuid');
 // eslint-disable-next-line import/order
 const debug = require('debug')('jest-mongodb:environment');
 
-const cwd = process.cwd();
-
-const globalConfigPath = pathJoin(cwd, 'globalConfig.json');
 const options = getMongodbMemoryOptions();
 const isReplSet = Boolean(options.replSet);
 
@@ -22,14 +19,16 @@ debug(`isReplSet`, isReplSet);
 const mongo = isReplSet ? new MongoMemoryReplSet(options) : new MongoMemoryServer(options);
 
 module.exports = class MongoEnvironment extends TestEnvironment {
+  globalConfigPath: string
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     super(config, context);
+    this.globalConfigPath = pathJoin(config.projectConfig.rootDir, 'globalConfig.json');
   }
 
   async setup() {
     debug('Setup MongoDB Test Environment');
 
-    const globalConfig = JSON.parse(readFileSync(globalConfigPath, 'utf-8'));
+    const globalConfig = JSON.parse(readFileSync(this.globalConfigPath, 'utf-8'));
 
     if (globalConfig.mongoUri) {
       this.global.__MONGO_URI__ = globalConfig.mongoUri;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -8,7 +8,7 @@ import {
   shouldUseSharedDBForAllJestWorkers,
 } from './helpers';
 import type {Mongo} from './types';
-import { JestEnvironmentConfig } from '@jest/environment'
+import type { JestEnvironmentConfig } from '@jest/environment'
 
 const debug = require('debug')('jest-mongodb:setup');
 const mongoMemoryServerOptions = getMongodbMemoryOptions();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -8,6 +8,7 @@ import {
   shouldUseSharedDBForAllJestWorkers,
 } from './helpers';
 import type {Mongo} from './types';
+import { JestEnvironmentConfig } from '@jest/environment'
 
 const debug = require('debug')('jest-mongodb:setup');
 const mongoMemoryServerOptions = getMongodbMemoryOptions();
@@ -20,10 +21,9 @@ const mongo: Mongo = isReplSet
   ? new MongoMemoryReplSet(mongoMemoryServerOptions)
   : new MongoMemoryServer(mongoMemoryServerOptions);
 
-const cwd = process.cwd();
-const globalConfigPath = join(cwd, 'globalConfig.json');
+module.exports = async (config: JestEnvironmentConfig['projectConfig']) => {
+  const globalConfigPath = join(config.rootDir, 'globalConfig.json');
 
-module.exports = async () => {
   const options = getMongodbMemoryOptions();
   const mongoConfig: {mongoUri?: string; mongoDBName?: string} = {};
 

--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -1,12 +1,12 @@
 import {join} from 'path';
 import {unlink} from 'fs';
+import { JestEnvironmentConfig } from '@jest/environment'
 
 const debug = require('debug')('jest-mongodb:teardown');
 
-const cwd = process.cwd();
-const globalConfigPath = join(cwd, 'globalConfig.json');
+module.exports = async function (config: JestEnvironmentConfig['projectConfig']) {
+  const globalConfigPath = join(config.rootDir, 'globalConfig.json');
 
-module.exports = async function () {
   debug('Teardown mongod');
   if (global.__MONGOD__) {
     await global.__MONGOD__.stop();

--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -1,6 +1,6 @@
 import {join} from 'path';
 import {unlink} from 'fs';
-import { JestEnvironmentConfig } from '@jest/environment'
+import type { JestEnvironmentConfig } from '@jest/environment'
 
 const debug = require('debug')('jest-mongodb:teardown');
 


### PR DESCRIPTION
Using `cwd` to determine the location to put the globalConfig.json causes a conflict between parallel test runs in a monorepo when Jest is invoked from the root of the repository and has a particular `jest.config` file specified.

This is how tools like [Nx](https://nx.dev/) invoke tests. Commands are run from the root of the repo and if I do something like 
`nx run-many --target=test --projects=project1,project2` this results in two separate `jest` commands being executed at the same time. Each command has the same `cwd` value (the repository root) but is pointed at a different `jest.config` file which specified which test files to run. This causes the runs to conflict, because when one of them finishes it will delete the globalConfig.json file which the other one then attempts to read for any test files it has left to execute.

Instead, switch to using the `rootDir` property of the jest environment config, which defaults to the location of the `jest.config` file currently in use for this test run.
https://jestjs.io/docs/configuration#rootdir-string