### PR TITLE
feat: Updated mongodb-memory-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "debug": "4.3.4",
-    "mongodb-memory-server": "8.8.0",
+    "mongodb-memory-server": "8.9.3",
     "uuid": "8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
@vladgolubev Is it possible to update mongodb-memory-server to 8.9.3? This is the latest version. I found out there is some issue with 8.8.0 working with ReplSet.

It works better on 8.9.3 with ReplSet.