### PR TITLE
refactor: replace uuid dependency for built in nodejs util

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   },
   "dependencies": {
     "debug": "4.3.4",
-    "mongodb-memory-server": "8.9.3",
-    "uuid": "8.3.2"
+    "mongodb-memory-server": "8.9.3"
   },
   "devDependencies": {
     "@babel/cli": "7.19.3",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -4,9 +4,8 @@ import {readFileSync} from 'fs';
 import type {EnvironmentContext} from '@jest/environment';
 import type {JestEnvironmentConfig} from '@jest/environment';
 import {MongoMemoryReplSet, MongoMemoryServer} from 'mongodb-memory-server';
+import {randomUUID} from 'crypto';
 import {getMongodbMemoryOptions} from './helpers';
-
-const uuid = require('uuid');
 
 // eslint-disable-next-line import/order
 const debug = require('debug')('jest-mongodb:environment');
@@ -38,7 +37,7 @@ module.exports = class MongoEnvironment extends TestEnvironment {
       this.global.__MONGO_URI__ = mongo.getUri();
     }
 
-    this.global.__MONGO_DB_NAME__ = globalConfig.mongoDBName || uuid.v4();
+    this.global.__MONGO_DB_NAME__ = globalConfig.mongoDBName || randomUUID();
 
     await super.setup();
   }


### PR DESCRIPTION
Hi,
I removed the uuid dependency because Node.js has a built in utility for v4 uuids since version 15.
Docs: https://nodejs.org/docs/latest-v16.x/api/crypto.html#cryptorandomuuidoptions
