### PR TITLE
fix global setup and teardown for jest multi-project setups

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -21,7 +21,7 @@ module.exports = class MongoEnvironment extends TestEnvironment {
   globalConfigPath: string;
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     super(config, context);
-    this.globalConfigPath = pathJoin(config.projectConfig.rootDir, 'globalConfig.json');
+    this.globalConfigPath = pathJoin(config.globalConfig.rootDir, 'globalConfig.json');
   }
 
   async setup() {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -21,8 +21,9 @@ const mongo: Mongo = isReplSet
   ? new MongoMemoryReplSet(mongoMemoryServerOptions)
   : new MongoMemoryServer(mongoMemoryServerOptions);
 
-module.exports = async (config: JestEnvironmentConfig['projectConfig']) => {
-  const globalConfigPath = join(config.rootDir, 'globalConfig.json');
+module.exports = async (config: JestEnvironmentConfig['globalConfig']) => {
+  const projects = config.projects.length ? config.projects : [config.rootDir];
+  const globalConfigPaths = projects.map(project => join(project, 'globalConfig.json'));
 
   const options = getMongodbMemoryOptions();
   const mongoConfig: {mongoUri?: string; mongoDBName?: string} = {};
@@ -48,6 +49,9 @@ module.exports = async (config: JestEnvironmentConfig['projectConfig']) => {
   mongoConfig.mongoDBName = options.instance.dbName;
 
   // Write global config to disk because all tests run in different contexts.
-  writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
+  // write one for each registered "project"
+  for (const path of globalConfigPaths) {
+    writeFileSync(path, JSON.stringify(mongoConfig));
+  }
   debug('Config is written');
 };

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -22,8 +22,7 @@ const mongo: Mongo = isReplSet
   : new MongoMemoryServer(mongoMemoryServerOptions);
 
 module.exports = async (config: JestEnvironmentConfig['globalConfig']) => {
-  const projects = config.projects.length ? config.projects : [config.rootDir];
-  const globalConfigPaths = projects.map(project => join(project, 'globalConfig.json'));
+  const globalConfigPath = join(config.rootDir, 'globalConfig.json');
 
   const options = getMongodbMemoryOptions();
   const mongoConfig: {mongoUri?: string; mongoDBName?: string} = {};
@@ -49,9 +48,6 @@ module.exports = async (config: JestEnvironmentConfig['globalConfig']) => {
   mongoConfig.mongoDBName = options.instance.dbName;
 
   // Write global config to disk because all tests run in different contexts.
-  // write one for each registered "project"
-  for (const path of globalConfigPaths) {
-    writeFileSync(path, JSON.stringify(mongoConfig));
-  }
+  writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
   debug('Config is written');
 };

--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -5,22 +5,18 @@ import type {JestEnvironmentConfig} from '@jest/environment';
 const debug = require('debug')('jest-mongodb:teardown');
 
 module.exports = async function (config: JestEnvironmentConfig['globalConfig']) {
-  const projects = config.projects.length ? config.projects : [config.rootDir];
-  const globalConfigPaths = projects.map(project => join(project, 'globalConfig.json'));
+  const globalConfigPath = join(config.rootDir, 'globalConfig.json');
 
   debug('Teardown mongod');
   if (global.__MONGOD__) {
     await global.__MONGOD__.stop();
   }
+  unlink(globalConfigPath, err => {
+    if (err) {
+      debug('Config could not be deleted');
 
-  for (const path of globalConfigPaths) {
-    unlink(path, err => {
-      if (err) {
-        debug('Config could not be deleted');
-
-        return;
-      }
-      debug('Config is deleted');
-    });
-  }
+      return;
+    }
+    debug('Config is deleted');
+  });
 };

--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -4,19 +4,23 @@ import type {JestEnvironmentConfig} from '@jest/environment';
 
 const debug = require('debug')('jest-mongodb:teardown');
 
-module.exports = async function (config: JestEnvironmentConfig['projectConfig']) {
-  const globalConfigPath = join(config.rootDir, 'globalConfig.json');
+module.exports = async function (config: JestEnvironmentConfig['globalConfig']) {
+  const projects = config.projects.length ? config.projects : [config.rootDir];
+  const globalConfigPaths = projects.map(project => join(project, 'globalConfig.json'));
 
   debug('Teardown mongod');
   if (global.__MONGOD__) {
     await global.__MONGOD__.stop();
   }
-  unlink(globalConfigPath, err => {
-    if (err) {
-      debug('Config could not be deleted');
 
-      return;
-    }
-    debug('Config is deleted');
-  });
+  for (const path of globalConfigPaths) {
+    unlink(path, err => {
+      if (err) {
+        debug('Config could not be deleted');
+
+        return;
+      }
+      debug('Config is deleted');
+    });
+  }
 };


### PR DESCRIPTION
Fix the issue created by https://github.com/shelfio/jest-mongodb/pull/389
Update the global setup and teardown to support having Jest "projects" specified. If specified, the preset will write a `globalSetup.json` file to each project directory, and remove all of them during teardown.

If the "projects" option is not in use, it will continue with the behaviour introduced in the above PR by writing a single `globalSetup.json` file to the `rootDir`.

This behaviour attempts to accommodate the use-case described in that PR without breaking the functionality for test setups using `projects`.

Edit:
Updated to instead use the globalConfig's "rootDir" field rather than the projectConfig in `environment.ts`. This field is set even when the `projects` option is in use. We only need to write one `globalConfig.json` file per Jest execution.