### PR TITLE
Drop peerDependency on jest-environment-node 27.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "jest-environment-node": "27.x.x || 28.x || 29.x",
+    "jest-environment-node": "28.x || 29.x",
     "mongodb": "3.x.x || 4.x || 5.x"
   },
   "engines": {


### PR DESCRIPTION
We import TestEnvironment from jest-environment-node, but it is exported only starting jest-environment-node version 28.

Fixes #406.