### PR TITLE
update to use config file location for finding jest mongodb config #436

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@shelf/jest-mongodb",
   "version": "4.1.7",
-  "private": false,
   "description": "Run your tests using Jest & MongoDB in Memory server",
   "keywords": [
     "jest",
@@ -63,6 +62,7 @@
     "eslint": "8.50.0",
     "husky": "8.0.3",
     "jest": "29.7.0",
+    "jest-environment-node": "29.6.4",
     "lint-staged": "13.3.0",
     "mongodb": "5.1.0",
     "prettier": "2.8.8",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,9 +1,8 @@
 import {resolve} from 'path';
 
-const cwd = process.cwd();
 const configFile = process.env.MONGO_MEMORY_SERVER_FILE || 'jest-mongodb-config.js';
 
-export function getMongodbMemoryOptions() {
+export function getMongodbMemoryOptions(cwd: string) {
   try {
     const {mongodbMemoryServerOptions} = require(resolve(cwd, configFile));
 
@@ -19,7 +18,7 @@ export function getMongodbMemoryOptions() {
   }
 }
 
-export function getMongoURLEnvName() {
+export function getMongoURLEnvName(cwd: string) {
   try {
     const {mongoURLEnvName} = require(resolve(cwd, configFile));
 
@@ -29,7 +28,7 @@ export function getMongoURLEnvName() {
   }
 }
 
-export function shouldUseSharedDBForAllJestWorkers() {
+export function shouldUseSharedDBForAllJestWorkers(cwd: string) {
   try {
     const {useSharedDBForAllJestWorkers} = require(resolve(cwd, configFile));
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,31 +11,34 @@ import {
 } from './helpers';
 
 const debug = require('debug')('jest-mongodb:setup');
-const mongoMemoryServerOptions = getMongodbMemoryOptions();
-const isReplSet = Boolean(mongoMemoryServerOptions.replSet);
-
-debug(`isReplSet ${isReplSet}`);
-
-// @ts-ignore
-const mongo: Mongo = isReplSet
-  ? new MongoMemoryReplSet(mongoMemoryServerOptions)
-  : new MongoMemoryServer(mongoMemoryServerOptions);
 
 module.exports = async (config: JestEnvironmentConfig['globalConfig']) => {
   const globalConfigPath = join(config.rootDir, 'globalConfig.json');
 
-  const options = getMongodbMemoryOptions();
+  const mongoMemoryServerOptions = getMongodbMemoryOptions(config.rootDir);
+  const isReplSet = Boolean(mongoMemoryServerOptions.replSet);
+
+  debug(`isReplSet ${isReplSet}`);
+
+  // @ts-ignore
+  const mongo: Mongo = isReplSet
+    ? new MongoMemoryReplSet(mongoMemoryServerOptions)
+    : new MongoMemoryServer(mongoMemoryServerOptions);
+
+  const options = getMongodbMemoryOptions(config.rootDir);
   const mongoConfig: {mongoUri?: string; mongoDBName?: string} = {};
 
-  debug(`shouldUseSharedDBForAllJestWorkers: ${shouldUseSharedDBForAllJestWorkers()}`);
+  debug(
+    `shouldUseSharedDBForAllJestWorkers: ${shouldUseSharedDBForAllJestWorkers(config.rootDir)}`
+  );
 
   // if we run one mongodb instance for all tests
-  if (shouldUseSharedDBForAllJestWorkers()) {
+  if (shouldUseSharedDBForAllJestWorkers(config.rootDir)) {
     if (!mongo.isRunning) {
       await mongo.start();
     }
 
-    const mongoURLEnvName = getMongoURLEnvName();
+    const mongoURLEnvName = getMongoURLEnvName(config.rootDir);
 
     mongoConfig.mongoUri = await mongo.getUri();
 


### PR DESCRIPTION
For the same usecase as specified in my other PR: https://github.com/shelfio/jest-mongodb/pull/389

In our monorepo there's currently a problem where executing tests from the root directory via Nx means that the preset does not look in the correct (project directory) location for the jest-mongodb-config.js file.

This updates the helpers that determine that file's location to get the cwd from Jest's globalConfig rather than reading it from process.cwd(). Since it needs to Jest config to do this, I moved the instantiation of the MongoMemoryServer class to be inside the environment class's constructor.

I also added a devDependency on jest-environment-node because Typescript was complaining about not having type definitions for it (since its listed as a peerDependency)

cc @ajwootto 