### PR TITLE
chore: add types for the configuration

### DIFF
--- a/jest-mongodb-config-repl.js
+++ b/jest-mongodb-config-repl.js
@@ -1,3 +1,4 @@
+/** @type {import('./src/types').Config} */
 module.exports = {
   mongodbMemoryServerOptions: {
     binary: {

--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -1,3 +1,4 @@
+/** @type {import('./src/types').Config} */
 module.exports = {
   mongodbMemoryServerOptions: {
     binary: {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,11 @@
 import {resolve} from 'path';
+import {Config} from './types';
 
 const configFile = process.env.MONGO_MEMORY_SERVER_FILE || 'jest-mongodb-config.js';
 
 export function getMongodbMemoryOptions(cwd: string) {
   try {
-    const {mongodbMemoryServerOptions} = require(resolve(cwd, configFile));
+    const {mongodbMemoryServerOptions}: Config = require(resolve(cwd, configFile));
 
     return mongodbMemoryServerOptions;
   } catch (e) {
@@ -20,7 +21,7 @@ export function getMongodbMemoryOptions(cwd: string) {
 
 export function getMongoURLEnvName(cwd: string) {
   try {
-    const {mongoURLEnvName} = require(resolve(cwd, configFile));
+    const {mongoURLEnvName}: Config = require(resolve(cwd, configFile));
 
     return mongoURLEnvName || 'MONGO_URL';
   } catch (e) {
@@ -30,7 +31,7 @@ export function getMongoURLEnvName(cwd: string) {
 
 export function shouldUseSharedDBForAllJestWorkers(cwd: string) {
   try {
-    const {useSharedDBForAllJestWorkers} = require(resolve(cwd, configFile));
+    const {useSharedDBForAllJestWorkers}: Config = require(resolve(cwd, configFile));
 
     if (typeof useSharedDBForAllJestWorkers === 'undefined') {
       return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,18 @@ declare global {
 }
 
 export type Mongo = (MongoMemoryReplSet | MongoMemoryServer) & {isRunning: boolean}
+
+type MongoMemoryReplSetOpts = NonNullable<ConstructorParameters<typeof MongoMemoryReplSet>[0]>;
+type MongoMemoryServerOpts = NonNullable<ConstructorParameters<typeof MongoMemoryServer>[0]>;
+
+export interface Config {
+  mongodbMemoryServerOptions?: MongoMemoryReplSetOpts | MongoMemoryServerOpts;
+  /**
+   * @default 'MONGO_URL'
+   */
+  mongoURLEnvName?: string;
+  /**
+   * @default true
+   */
+  useSharedDBForAllJestWorkers?: boolean;
+}


### PR DESCRIPTION
This defines types for the config file, which can help when modifying the config file, as you can use a jsdoc type annotation to define the type and get some editor hints for the configuration options.

#### `jest-mongodb-config.js`

```js
/** @type {import('@shelf/jest-mongodb').Config} */
module.exports = {
  mongodbMemoryServerOptions: {
    binary: {
      version: '4.0.3',
      skipMD5: true,
    },
    autoStart: false,
    instance: {},
  },
};
```